### PR TITLE
docs: Fedora 43 updated installation instruction

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -211,6 +211,21 @@ gpgkey=https://minecraft-linux.github.io/pkg/deb/pubkey.gpg
 EOF
 ```
 
+### 43 (x86_64 / arm64)
+```
+sudo tee /etc/yum.repos.d/minecraft-linux-pkg.repo << 'EOL'
+[minecraft-linux-pkg]
+name=minecraft-linux-pkg
+baseurl=https://minecraft-linux.github.io/pkg/fedora-43
+enabled=1
+countme=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+skip_if_unavailable=False
+gpgkey=https://minecraft-linux.github.io/pkg/deb/pubkey.gpg
+EOL
+```
 ## Nightly
 
 ### 38 (x86_64 / arm64)


### PR DESCRIPTION
## Problem
The current command in the README doesn't work on Fedora 43:
```bash
cat | sudo tee /etc/yum.repos.d/minecraft-linux-pkg.repo << 'EOF'
```

The `cat |` syntax is broken and prevents users from adding the repository.

## Solution
Removed the unnecessary `cat |` pipe, simplified to:
```bash
sudo tee /etc/yum.repos.d/minecraft-linux-pkg.repo << EOL
```

Updated the base url 
```
baseurl=https://minecraft-linux.github.io/pkg/fedora-43
```

### Testing
- Tested on Fedora 43
- Repository added successfully
- Package installs correctly using the fedora-43 baseurl

Updated the new baseurl as asked in #26 